### PR TITLE
Type hinting support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,8 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
+      - run: npm install
+        working-directory: ./examples
       - run: npm test
         env:
           NODE_OPTIONS: --test-reporter spec

--- a/README.md
+++ b/README.md
@@ -84,13 +84,11 @@ const { ok, strictEqual } = require("node:assert");
 const { onExecutePostLogin } = require("./code");
 
 // Import the setup for Node Test Runner
-const {
-  actionTestSetup,
-} = require("@kilterset/auth0-actions-testing/node-test-runner");
+const { nodeTestRunner } = require("@kilterset/auth0-actions-testing");
 
 test("Lucky Number", async (t) => {
   // Set up the test context
-  const { auth0 } = await actionTestSetup(t);
+  const { auth0 } = await nodeTestRunner.actionTestSetup(t);
 
   // Each test case needs an `await t.test(...)` call
   await t.test("records a lucky number", async () => {

--- a/examples/app-metadata.test.js
+++ b/examples/app-metadata.test.js
@@ -1,13 +1,10 @@
 const test = require("node:test");
 const { ok, strictEqual } = require("node:assert");
 const { onExecutePostLogin } = require("./app-metadata");
-
-const {
-  actionTestSetup,
-} = require("@kilterset/auth0-actions-testing/node-test-runner");
+const { nodeTestRunner } = require("@kilterset/auth0-actions-testing");
 
 test("setting app metadata", async (t) => {
-  const { auth0 } = await actionTestSetup(t);
+  const { auth0 } = await nodeTestRunner.actionTestSetup(t);
 
   await t.test("records a lucky number", async () => {
     const action = auth0.mock.actions.postLogin({

--- a/examples/fetch-formdata.test.js
+++ b/examples/fetch-formdata.test.js
@@ -1,13 +1,10 @@
 const test = require("node:test");
 const { strictEqual, deepStrictEqual, rejects } = require("node:assert");
 const { onExecutePostLogin } = require("./fetch-formdata");
-
-const {
-  actionTestSetup,
-} = require("@kilterset/auth0-actions-testing/node-test-runner");
+const { nodeTestRunner } = require("@kilterset/auth0-actions-testing");
 
 test("fetch with FormData (www-form-urlencoded)", async (t) => {
-  const { auth0, fetchMock } = await actionTestSetup(t);
+  const { auth0, fetchMock } = await nodeTestRunner.actionTestSetup(t);
 
   await t.test("service is notified when user logs in", async (t) => {
     fetchMock.mock("https://api.example.com/notify-user-logged-in", 201);

--- a/examples/fetch-json.test.js
+++ b/examples/fetch-json.test.js
@@ -1,13 +1,10 @@
 const test = require("node:test");
 const { strictEqual, deepStrictEqual, rejects } = require("node:assert");
 const { onExecutePostLogin } = require("./fetch-json");
-
-const {
-  actionTestSetup,
-} = require("@kilterset/auth0-actions-testing/node-test-runner");
+const { nodeTestRunner } = require("@kilterset/auth0-actions-testing");
 
 test("fetch with JSON", async (t) => {
-  const { auth0, fetchMock } = await actionTestSetup(t);
+  const { auth0, fetchMock } = await nodeTestRunner.actionTestSetup(t);
 
   await t.test("service is notified when user logs in", async (t) => {
     const responseJSON = { notificationWasSuccessful: true };

--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -1,0 +1,37 @@
+{
+  "name": "examples",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "examples",
+      "version": "1.0.0",
+      "dependencies": {
+        "@kilterset/auth0-actions-testing": "file:.."
+      }
+    },
+    "..": {
+      "name": "@kilterset/auth0-actions-testing",
+      "version": "0.0.4",
+      "license": "ISC",
+      "dependencies": {
+        "@types/chance": "^1.1.6",
+        "@types/fetch-mock": "^7.3.8",
+        "@types/node": "^20.11.20",
+        "chance": "^1.1.11",
+        "fetch-mock": "^9.11.0",
+        "fishery": "^2.2.2",
+        "node-fetch": "^2.7.0",
+        "typescript": "^5.3.3"
+      },
+      "devDependencies": {
+        "@types/node-fetch": "^2.6.11"
+      }
+    },
+    "node_modules/@kilterset/auth0-actions-testing": {
+      "resolved": "..",
+      "link": true
+    }
+  }
+}

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "examples",
+  "version": "1.0.0",
+  "dependencies": {
+    "@kilterset/auth0-actions-testing": "file:.."
+  }
+}

--- a/examples/redirect.test.js
+++ b/examples/redirect.test.js
@@ -1,19 +1,10 @@
 const test = require("node:test");
 const { strictEqual, deepStrictEqual, ok, strict } = require("node:assert");
 const { onExecutePostLogin, onContinuePostLogin } = require("./redirect");
-
-const {
-  signHS256,
-  encodeHS256JWT,
-  decodeJWTPayload,
-} = require("@kilterset/auth0-actions-testing/jwt");
-
-const {
-  actionTestSetup,
-} = require("@kilterset/auth0-actions-testing/node-test-runner");
+const { nodeTestRunner, jwt } = require("@kilterset/auth0-actions-testing");
 
 test("redirect and continue with signed data", async (t) => {
-  const { auth0 } = await actionTestSetup(t);
+  const { auth0 } = await nodeTestRunner.actionTestSetup(t);
 
   await t.test("redirects with signed data", async (t) => {
     const action = auth0.mock.actions.postLogin({
@@ -51,7 +42,7 @@ test("redirect and continue with signed data", async (t) => {
     // Test the signed JWT data payload
     const { session_token } = redirect.queryParams;
 
-    const decoded = decodeJWTPayload(session_token);
+    const decoded = jwt.decodeJWTPayload(session_token);
 
     strictEqual(decoded.sub, "007", "Unexpected sub claim");
 
@@ -66,7 +57,7 @@ test("redirect and continue with signed data", async (t) => {
     // Test the JWT was signed with the correct shared secret
     const [header, payload, signature] = session_token.split(".");
     const body = `${header}.${payload}`;
-    const expectedSignature = signHS256({ body, secret: "shh" });
+    const expectedSignature = jwt.signHS256({ body, secret: "shh" });
     strictEqual(signature, expectedSignature, "Unexpected JWT signature");
   });
 
@@ -82,7 +73,7 @@ test("redirect and continue with signed data", async (t) => {
       sandwich: "tuna", // custom claim
     };
 
-    const jwtFromApp = encodeHS256JWT({ claims, secret: "shh" });
+    const jwtFromApp = jwt.encodeHS256JWT({ claims, secret: "shh" });
 
     // Then your app redirects the user back to the continue URL with the state
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "@kilterset/auth0-actions-testing",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kilterset/auth0-actions-testing",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "license": "ISC",
       "dependencies": {
         "@types/chance": "^1.1.6",
+        "@types/fetch-mock": "^7.3.8",
         "@types/node": "^20.11.20",
         "chance": "^1.1.11",
         "fetch-mock": "^9.11.0",
@@ -46,25 +47,25 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.1.tgz",
-      "integrity": "sha512-Pc65opHDliVpRHuKfzI+gSA4zcgr65O4cl64fFJIWEEh8JoHIHh0Oez1Eo8Arz8zq/JhgKodQaxEwUPRtZylVA==",
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.4.tgz",
+      "integrity": "sha512-vg8Gih2MLK+kOkHJp4gBEIkyaIi00jgWot2D9QOmmfLC8jINSOzmCLta6Bvz/JSBCqnegV0L80jhxkol5GWNfQ==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.24.3",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.3.tgz",
-      "integrity": "sha512-5FcvN1JHw2sHJChotgx8Ek0lyuh4kCKelgMTTqhYJJtloNvUfpAFMeNQUtdlIaktwrSV9LtCdqwk48wL2wBacQ==",
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.4.tgz",
+      "integrity": "sha512-MBVlMXP+kkl5394RBLSxxk/iLTeVGuXTV3cIDXavPpMMqnSnt6apKgan/U8O3USWZCWZT/TbgfEpKa4uMgN4Dg==",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.24.2",
-        "@babel/generator": "^7.24.1",
+        "@babel/generator": "^7.24.4",
         "@babel/helper-compilation-targets": "^7.23.6",
         "@babel/helper-module-transforms": "^7.23.3",
-        "@babel/helpers": "^7.24.1",
-        "@babel/parser": "^7.24.1",
+        "@babel/helpers": "^7.24.4",
+        "@babel/parser": "^7.24.4",
         "@babel/template": "^7.24.0",
         "@babel/traverse": "^7.24.1",
         "@babel/types": "^7.24.0",
@@ -83,9 +84,9 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.1.tgz",
-      "integrity": "sha512-DfCRfZsBcrPEHUfuBMgbJ1Ut01Y/itOs+hY2nFLgqsqXd52/iSiVq5TITtUasIUgm+IIKdY2/1I7auiQOEeC9A==",
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.4.tgz",
+      "integrity": "sha512-Xd6+v6SnjWVx/nus+y0l1sxMOTOMBkyL4+BIdbALyatQnAe/SRVjANeDPSCYaX+i1iJmuGSKf3Z+E+V/va1Hvw==",
       "dependencies": {
         "@babel/types": "^7.24.0",
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -218,9 +219,9 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.1.tgz",
-      "integrity": "sha512-BpU09QqEe6ZCHuIHFphEFgvNSrubve1FtyMton26ekZ85gRGi6LrTF7zArARp2YvyFxloeiRmtSCq5sjh1WqIg==",
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.4.tgz",
+      "integrity": "sha512-FewdlZbSiwaVGlgT1DPANDuCHaDMiOo+D/IDYRFYjHOuv66xMSJ7fQwwODwRNAPkADIO/z1EoF/l2BCWlWABDw==",
       "dependencies": {
         "@babel/template": "^7.24.0",
         "@babel/traverse": "^7.24.1",
@@ -245,9 +246,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.1.tgz",
-      "integrity": "sha512-Zo9c7N3xdOIQrNip7Lc9wvRPzlRtovHVE4lkz8WEDr7uYh/GMQhSiIgFxGIArRHYdJE5kxtZjAf8rT0xhdLCzg==",
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.4.tgz",
+      "integrity": "sha512-zTvEBcghmeBma9QIGunWevvBAp4/Qu9Bdq+2k0Ot4fVMD6v3dsC9WOcRSKk7tRRyBM/53yKMJko9xOatGQAwSg==",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -256,9 +257,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.1.tgz",
-      "integrity": "sha512-+BIznRzyqBf+2wCTxcKE3wDjfGeCoVE61KSHGpkzqrLi8qxqFwBeUFyId2cxkTmm55fzDGnm0+yCxaxygrLUnQ==",
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.4.tgz",
+      "integrity": "sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -360,10 +361,15 @@
       "resolved": "https://registry.npmjs.org/@types/chance/-/chance-1.1.6.tgz",
       "integrity": "sha512-V+pm3stv1Mvz8fSKJJod6CglNGVqEQ6OyuqitoDkWywEODM/eJd1eSuIp9xt6DrX8BWZ2eDSIzbw1tPCUTvGbQ=="
     },
+    "node_modules/@types/fetch-mock": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/@types/fetch-mock/-/fetch-mock-7.3.8.tgz",
+      "integrity": "sha512-ztsIGiyUvD0GaqPc9/hb8k20gnr6lupqA6SFtqt+8v2mtHhNO/Ebb6/b7N6af/7x0A7s1C8nxrEGzajMBqz8qA=="
+    },
     "node_modules/@types/node": {
-      "version": "20.12.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.2.tgz",
-      "integrity": "sha512-zQ0NYO87hyN6Xrclcqp7f8ZbXNbRfoGWNcMvHTPQp9UUrwI0mI7XBz+cu7/W6/VClYo2g63B0cjull/srU7LgQ==",
+      "version": "20.12.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.3.tgz",
+      "integrity": "sha512-sD+ia2ubTeWrOu+YMF+MTAB7E+O7qsMqAbMfW7DG3K1URwhZ5hN1pLlRVGbf4wDFzSfikL05M17EyorS86jShw==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -427,9 +433,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001603",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001603.tgz",
-      "integrity": "sha512-iL2iSS0eDILMb9n5yKQoTBim9jMZ0Yrk8g0N9K7UzYyWnfIKzXBZD5ngpM37ZcL/cv0Mli8XtVMRYMQAfFpi5Q==",
+      "version": "1.0.30001605",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001605.tgz",
+      "integrity": "sha512-nXwGlFWo34uliI9z3n6Qc0wZaf7zaZWA1CPZ169La5mV3I/gem7bst0vr5XQH5TJXZIMfDeZyOrZnSlVzKxxHQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -529,9 +535,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.723",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.723.tgz",
-      "integrity": "sha512-rxFVtrMGMFROr4qqU6n95rUi9IlfIm+lIAt+hOToy/9r6CDv0XiEcQdC3VP71y1pE5CFTzKV0RvxOGYCPWWHPw=="
+      "version": "1.4.724",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.724.tgz",
+      "integrity": "sha512-RTRvkmRkGhNBPPpdrgtDKvmOEYTrPlXDfc0J/Nfq5s29tEahAwhiX4mmhNzj6febWMleulxVYPh7QwCSL/EldA=="
     },
     "node_modules/escalade": {
       "version": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,20 +1,22 @@
 {
   "name": "@kilterset/auth0-actions-testing",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Test and develop Auth0 Actions or Okta CIC Actions locally.",
   "scripts": {
     "test": "npm run test:src && npm run test:examples",
     "test:src": "node --test $(find dist -name *.test.js)",
     "test:examples": "node --test examples",
-    "build": "tsc --build",
+    "build": "tsc --build && npm run build:copy-declarations",
     "build:watch": "tsc --watch",
-    "clean": "tsc --build --clean"
+    "build:clean": "rm -rf dist; npm run build",
+    "build:copy-declarations": "cd src && rsync -Rv $(find . -name '*.d.ts') ../dist/"
   },
   "author": "Pete Nicholls <pnicholls@kilterset.com>",
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
     "@types/chance": "^1.1.6",
+    "@types/fetch-mock": "^7.3.8",
     "@types/node": "^20.11.20",
     "chance": "^1.1.11",
     "fetch-mock": "^9.11.0",
@@ -22,12 +24,9 @@
     "node-fetch": "^2.7.0",
     "typescript": "^5.3.3"
   },
-  "exports": {
-    ".": "./dist/index.js",
-    "./node-test-runner": "./dist/test-runners/node-test-runner/index.js",
-    "./jwt": "./dist/jwt/index.js"
-  },
   "devDependencies": {
     "@types/node-fetch": "^2.6.11"
-  }
+  },
+  "main": "dist/index.js",
+  "typings": "dist/index.d.ts"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,3 @@
 export * as mock from "./mock";
+export * as jwt from "./jwt";
+export * as nodeTestRunner from "./test-runners/node-test-runner";

--- a/src/test-runners/node-test-runner/fetch-mock.ts
+++ b/src/test-runners/node-test-runner/fetch-mock.ts
@@ -1,10 +1,9 @@
 import { TestContext } from "./test-context";
-
-const { polyfillFetch } = require("./polyfill-fetch");
+import { polyfillFetch } from "./polyfill-fetch";
 
 export async function configureFetchMock(testContext: TestContext) {
   await polyfillFetch(testContext);
-  const mockFetch = require("fetch-mock");
-  testContext.afterEach(mockFetch.restore);
-  return mockFetch;
+  const { default: fetchMock } = await import("fetch-mock");
+  testContext.afterEach(fetchMock.restore);
+  return fetchMock;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -49,10 +49,10 @@
     // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
 
     /* Emit */
-    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
-    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+    "declaration": true /* Generate .d.ts files from TypeScript and JavaScript files in your project. */,
+    "declarationMap": true /* Create sourcemaps for d.ts files. */,
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
-    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    "sourceMap": true /* Create source map files for emitted JavaScript files. */,
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
     "outDir": "./dist" /* Specify an output folder for all emitted files. */,


### PR DESCRIPTION
In order to get this to work with commonjs modules, we tried a few options. The most reliable proved to be moving all the exports into a single file, as the `exports` map exhibited stubborn behaviour when trying to get type definitions and commonjs working well together.

As part of this change, we had to add a `package.json` with a relative reference to the parent library within the `examples`.