### PR TITLE
Change state.access structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 Allows you to develop and test Auth0 Actions and Okta CIC Actions locally. This project is not affilliated with Auth0.
 
+**Pre-release:** The API and type definitions may change before a `1.0` release.
+
 This library provides you with the setup to test complex actions. Customise test event payloads using realistic, randomized data. Test Action behaviour such as `fetch`ing an external service, providing event secrets, setting metadata, caching data, denying access, redirecting users mid-login, and more. Provides type-hinting to your editor.
 
 The following [Flows](https://auth0.com/docs/customize/actions/flows-and-triggers) are supported:

--- a/examples/geo-filter.test.js
+++ b/examples/geo-filter.test.js
@@ -1,5 +1,5 @@
 const test = require("node:test");
-const { ok, strictEqual } = require("node:assert");
+const { ok, deepStrictEqual } = require("node:assert");
 const { onExecuteCredentialsExchange } = require("./geo-filter");
 const { nodeTestRunner } = require("@kilterset/auth0-actions-testing");
 
@@ -15,16 +15,13 @@ test("Filter access based on continent code", async (t) => {
 
     ok(action.access.denied, "Expected access to be denied");
 
-    strictEqual(
-      action.access.denied.code,
-      "invalid_request",
-      "Unexpected denial code"
-    );
-
-    strictEqual(
-      action.access.denied.reason,
-      "Access from North America is not allowed.",
-      "Unexpected denial reason"
+    deepStrictEqual(
+      action.access.denied,
+      {
+        code: "invalid_request",
+        reason: "Access from North America is not allowed.",
+      },
+      "Unexpected denial"
     );
   });
 

--- a/src/mock/api/credentials-exchange.ts
+++ b/src/mock/api/credentials-exchange.ts
@@ -20,7 +20,7 @@ export function credentialsExchange({
 }: CredentialsExchangeOptions = {}) {
   const apiCache = mockCache(cache);
   const access = accessMock("CredentialsExchange");
-  const accessToken = accessTokenMock("CredentialsExchange")
+  const accessToken = accessTokenMock("CredentialsExchange");
 
   const state: CredentialsExchangeState = {
     access: access.state,

--- a/src/mock/api/post-login.ts
+++ b/src/mock/api/post-login.ts
@@ -100,10 +100,16 @@ export function postLogin({
   const apiCache = mockCache(cache);
   const access = accessMock("PostLogin");
   const accessToken = accessTokenMock("PostLogin");
-  const authentication = authenticationMock("PostLogin", { userId: userValue.user_id });
+  const authentication = authenticationMock("PostLogin", {
+    userId: userValue.user_id,
+  });
   const idToken = idTokenMock("PostLogin");
   const multifactor = multifactorMock("PostLogin");
-  const redirect = redirectMock("PostLogin", { now, request: requestValue, user: userValue });
+  const redirect = redirectMock("PostLogin", {
+    now,
+    request: requestValue,
+    user: userValue,
+  });
   const userApiMock = userMock("PostLogin", { user: userValue });
   const samlResponse = samlResponseMock("PostLogin");
   const validation = validationMock("PostLogin");
@@ -124,7 +130,7 @@ export function postLogin({
 
   const api: Auth0.API.PostLogin = {
     get access() {
-      return access.build(api)
+      return access.build(api);
     },
 
     get accessToken() {

--- a/src/test/api/post-login.test.ts
+++ b/src/test/api/post-login.test.ts
@@ -7,11 +7,8 @@ import { encodeHS256JWT } from "../../jwt/hs256";
 test("PostLogin API", async (t) => {
   await t.test("access", async (t) => {
     const { implementation: api, state } = postLogin();
-
     strictEqual(api.access.deny("Only cool kids allowed"), api);
-
-    ok(state.access.denied, "Expected access to be denied");
-    strictEqual(state.access.denied.reason, "Only cool kids allowed");
+    deepStrictEqual(state.access.denied, { reason: "Only cool kids allowed" });
   });
 
   await t.test("accessToken", async (t) => {
@@ -425,8 +422,16 @@ test("PostLogin API", async (t) => {
         const { redirect } = state;
 
         ok(redirect.target, "redirect not set");
-        deepStrictEqual(redirect.target.queryParams, {}, "query should be empty");
-        strictEqual(redirect.target.url.href, "https://example.com/r", "url mismatch");
+        deepStrictEqual(
+          redirect.target.queryParams,
+          {},
+          "query should be empty"
+        );
+        strictEqual(
+          redirect.target.url.href,
+          "https://example.com/r",
+          "url mismatch"
+        );
       });
 
       await t.test("redirect with consolidated GET parameters", async (t) => {


### PR DESCRIPTION
`access` could look like:

```ts
{
  denied: true,
  code: "not_allowed",
  reason: "Nobody's allowed to sign in on Tuesdays"
}
```

This leads to tests like this:

```ts
ok(access.denied)
strictEqual(access.reason, ...)
```

This changes the structure to:

```ts
{
  denied: { code: "...", reason: "..." }
}
```

and:

```ts
ok(access.denied)
strictEqual(access.denied.reason, ...)
```