### PR TITLE
Make redirect state consistent between APIs

### DIFF
--- a/examples/Login/redirect.test.js
+++ b/examples/Login/redirect.test.js
@@ -21,26 +21,26 @@ test("redirect and continue with signed data", async (t) => {
     const { redirect } = action;
 
     strict(
-      redirect.target.queryParams.theme,
+      redirect.queryParams.theme,
       "spiffy",
       "Unexpected value for `theme` query parameter"
     );
 
     strictEqual(
       // You can also use redirect.url.href to get the full URL as a string
-      redirect.target.url.origin,
+      redirect.url.origin,
       "https://example.com",
       "Unexpected redirect URL origin"
     );
 
     strictEqual(
-      redirect.target.url.pathname,
+      redirect.url.pathname,
       "/sandwich-preferences",
       "Unexpected redirect URL path"
     );
 
     // Test the signed JWT data payload
-    const { session_token } = redirect.target.queryParams;
+    const { session_token } = redirect.queryParams;
 
     const decoded = jwt.decodeJWTPayload(session_token);
 

--- a/src/mock/api/post-login.ts
+++ b/src/mock/api/post-login.ts
@@ -80,9 +80,7 @@ export interface PostLoginState {
   validation: {
     error: { code: string; message: string } | null;
   };
-  redirect: {
-    target: { url: URL; queryParams: Record<string, string> } | null;
-  };
+  redirect: { url: URL; queryParams: Record<string, string> } | null;
 }
 
 export function postLogin({
@@ -125,7 +123,9 @@ export function postLogin({
     multifactor: multifactor.state,
     samlResponse: samlResponse.state,
     validation: validation.state,
-    redirect: redirect.state,
+    get redirect() {
+      return redirect.state.target;
+    },
   };
 
   const api: Auth0.API.PostLogin = {

--- a/src/mock/api/redirect.ts
+++ b/src/mock/api/redirect.ts
@@ -11,7 +11,7 @@ interface RedirectMockOptions {
 interface EncodeTokenOptions {
   expiresInSeconds?: number | undefined;
   payload: {
-      [key: string]: unknown;
+    [key: string]: unknown;
   };
   secret: string;
 }
@@ -25,7 +25,10 @@ interface ValidateTokenOptions {
   secret: string;
 }
 
-export function redirectMock(flow: string, { now: nowValue, request, user }: RedirectMockOptions) {
+export function redirectMock(
+  flow: string,
+  { now: nowValue, request, user }: RedirectMockOptions
+) {
   const now = new Date(nowValue || Date.now());
 
   const state = {
@@ -33,7 +36,11 @@ export function redirectMock(flow: string, { now: nowValue, request, user }: Red
   };
 
   const build = <T>(api: T) => ({
-    encodeToken: ({ expiresInSeconds, payload, secret }: EncodeTokenOptions) => {
+    encodeToken: ({
+      expiresInSeconds,
+      payload,
+      secret,
+    }: EncodeTokenOptions) => {
       expiresInSeconds = expiresInSeconds ?? 900;
 
       const claims = {

--- a/src/mock/api/user.ts
+++ b/src/mock/api/user.ts
@@ -1,7 +1,7 @@
 import { User } from "../../types";
 
-export function userMock(flow: string, { user }: { user: User}) {
-  const state = user
+export function userMock(flow: string, { user }: { user: User }) {
+  const state = user;
 
   const build = <T>(api: T) => ({
     setAppMetadata: (key: string, value: unknown) => {
@@ -16,5 +16,5 @@ export function userMock(flow: string, { user }: { user: User}) {
     },
   });
 
-  return { build, state }
+  return { build, state };
 }

--- a/src/test/api/post-login.test.ts
+++ b/src/test/api/post-login.test.ts
@@ -421,17 +421,9 @@ test("PostLogin API", async (t) => {
 
         const { redirect } = state;
 
-        ok(redirect.target, "redirect not set");
-        deepStrictEqual(
-          redirect.target.queryParams,
-          {},
-          "query should be empty"
-        );
-        strictEqual(
-          redirect.target.url.href,
-          "https://example.com/r",
-          "url mismatch"
-        );
+        ok(redirect, "redirect not set");
+        deepStrictEqual(redirect.queryParams, {}, "query should be empty");
+        strictEqual(redirect.url.href, "https://example.com/r", "url mismatch");
       });
 
       await t.test("redirect with consolidated GET parameters", async (t) => {
@@ -446,16 +438,16 @@ test("PostLogin API", async (t) => {
 
         const { redirect } = state;
 
-        ok(redirect.target, "redirect not set");
+        ok(redirect, "redirect not set");
 
         deepStrictEqual(
-          redirect.target.queryParams,
+          redirect.queryParams,
           { bread: "rye", filling: "cheese", spread: "butter" },
           "unexpected query"
         );
 
         strictEqual(
-          redirect.target.url.href,
+          redirect.url.href,
           "https://example.com/?bread=rye&filling=cheese&spread=butter",
           "url mismatch"
         );

--- a/src/test/api/redirect.test.ts
+++ b/src/test/api/redirect.test.ts
@@ -15,7 +15,11 @@ test("redirect", async (t) => {
       ip: "d666:171e:e7a4:1aa3:359a:a317:9f53:ee97",
     });
     const user = mockUser({ user_id: "auth0|8150" });
-    const { build, state } = redirectMock("Another Flow", { now, request, user });
+    const { build, state } = redirectMock("Another Flow", {
+      now,
+      request,
+      user,
+    });
     const api = build(baseApi);
 
     const token = api.encodeToken({
@@ -52,7 +56,7 @@ test("redirect", async (t) => {
       signature,
       "ZlLKLk7uJzDjD0nt2a08QiWMY1EPnhFIuc8WsSZPBvQ",
       "invalid signature"
-    ); 
+    );
   });
 
   await t.test("sendUserTo", async (t) => {
@@ -60,21 +64,33 @@ test("redirect", async (t) => {
       const now = new Date();
       const request = mockRequest();
       const user = mockUser();
-      const { build, state } = redirectMock("Another Flow", { now, request, user });
+      const { build, state } = redirectMock("Another Flow", {
+        now,
+        request,
+        user,
+      });
       const api = build(baseApi);
 
-      strictEqual(api.sendUserTo("https://example.com/r"), baseApi, );
+      strictEqual(api.sendUserTo("https://example.com/r"), baseApi);
 
       ok(state.target, "redirect not set");
       deepStrictEqual(state.target.queryParams, {}, "query should be empty");
-      strictEqual(state.target.url.href, "https://example.com/r", "url mismatch");
+      strictEqual(
+        state.target.url.href,
+        "https://example.com/r",
+        "url mismatch"
+      );
     });
 
     await t.test("redirect with consolidated GET parameters", async (t) => {
       const now = new Date();
       const request = mockRequest();
       const user = mockUser();
-      const { build, state } = redirectMock("Another Flow", { now, request, user });
+      const { build, state } = redirectMock("Another Flow", {
+        now,
+        request,
+        user,
+      });
       const api = build(baseApi);
 
       strictEqual(
@@ -140,7 +156,11 @@ test("redirect", async (t) => {
           state: VALID_STATE,
         },
       });
-      const { build, state } = redirectMock("Another Flow", { now, request, user });
+      const { build, state } = redirectMock("Another Flow", {
+        now,
+        request,
+        user,
+      });
       const api = build(baseApi);
 
       const payload = api.validateToken({ secret: VALID_SECRET });
@@ -157,7 +177,11 @@ test("redirect", async (t) => {
           state: VALID_STATE,
         },
       });
-      const { build, state } = redirectMock("Another Flow", { now, request, user });
+      const { build, state } = redirectMock("Another Flow", {
+        now,
+        request,
+        user,
+      });
       const api = build(baseApi);
 
       const payload = api.validateToken({ secret: VALID_SECRET });
@@ -174,7 +198,11 @@ test("redirect", async (t) => {
           state: VALID_STATE,
         },
       });
-      const { build, state } = redirectMock("Another Flow", { now, request, user });
+      const { build, state } = redirectMock("Another Flow", {
+        now,
+        request,
+        user,
+      });
       const api = build(baseApi);
 
       const payload = api.validateToken({
@@ -214,13 +242,13 @@ test("redirect", async (t) => {
     await t.test("throws error if expired", async (t) => {
       const { user, request } = VALID_CONTEXT;
       const now = TOKEN_PAYLOAD.exp * 1000; // exactly the expiry time
-      const { build, state } = redirectMock("Another Flow", { ...VALID_CONTEXT, now });
+      const { build, state } = redirectMock("Another Flow", {
+        ...VALID_CONTEXT,
+        now,
+      });
       const api = build(baseApi);
 
-      throws(
-        () => api.validateToken({ secret: VALID_SECRET }),
-        /expired/i
-      );
+      throws(() => api.validateToken({ secret: VALID_SECRET }), /expired/i);
     });
 
     await t.test("throws error if signature is invalid", async (t) => {
@@ -232,10 +260,7 @@ test("redirect", async (t) => {
       const { build, state } = redirectMock("Another Flow", context);
       const api = build(baseApi);
 
-      throws(
-        () => api.validateToken({ secret: VALID_SECRET }),
-        /signature/i
-      );
+      throws(() => api.validateToken({ secret: VALID_SECRET }), /signature/i);
     });
 
     for (const claim of ["sub", "iss", "iat", "exp"]) {


### PR DESCRIPTION
PostLogin had `state.redirect.target` whereas PostChallenge had `state.redirect`.
