### PR TITLE
Add mock prompt API for testing rendering of forms

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kilterset/auth0-actions-testing",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Test and develop Auth0 Actions or Okta CIC Actions locally.",
   "repository": "https://github.com/kilterset/auth0-actions-testing",
   "homepage": "https://github.com/kilterset/auth0-actions-testing#readme",

--- a/src/mock/api/post-login.ts
+++ b/src/mock/api/post-login.ts
@@ -7,6 +7,7 @@ import { accessMock } from "./access";
 import { authenticationMock, FactorList } from "./authentication";
 import { idTokenMock } from "./id-token";
 import { multifactorMock } from "./multifactor";
+import { promptMock } from "./prompt";
 import { redirectMock } from "./redirect";
 import { userMock } from "./user";
 import { samlResponseMock } from "./saml-response";
@@ -103,6 +104,7 @@ export function postLogin({
   });
   const idToken = idTokenMock("PostLogin");
   const multifactor = multifactorMock("PostLogin");
+  const prompt = promptMock("PostLogin");
   const redirect = redirectMock("PostLogin", {
     now,
     request: requestValue,
@@ -149,6 +151,10 @@ export function postLogin({
 
     get multifactor() {
       return multifactor.build(api);
+    },
+
+    get prompt() {
+      return prompt.build(api);
     },
 
     get redirect() {

--- a/src/mock/api/prompt.ts
+++ b/src/mock/api/prompt.ts
@@ -1,0 +1,20 @@
+import { MultifactorEnableOptions } from "../../types";
+
+interface PromptState {
+  promptId: string;
+  promptOptions?: { [key: string]: unknown };
+}
+
+export function promptMock(flow: string) {
+  const state: { rendered: PromptState | null } = {
+    rendered: null,
+  };
+
+  const build = <T>(api: T) => ({
+    render: (promptId: string, promptOptions?: { [key: string]: unknown }) => {
+      state.rendered = { promptId, promptOptions };
+    },
+  });
+
+  return { state, build };
+}

--- a/src/test/api/prompt.test.ts
+++ b/src/test/api/prompt.test.ts
@@ -1,0 +1,23 @@
+import { deepStrictEqual, ok, strictEqual } from "node:assert";
+import test from "node:test";
+import { promptMock } from "../../mock/api/prompt";
+
+test("prompt", async (t) => {
+  const baseApi = Symbol("Base API");
+
+  await t.test("render", async (t) => {
+    const { build, state } = promptMock("Another Flow");
+    const api = build(baseApi);
+
+    strictEqual(state.rendered, null);
+
+    api.render("prompt-id", { fields: { foo: "bar" } });
+
+    ok(Boolean(state.rendered), "Expected prompt to be rendered");
+
+    deepStrictEqual(state.rendered, {
+      promptId: "prompt-id",
+      promptOptions: { fields: { foo: "bar" } },
+    });
+  });
+});

--- a/src/types/api/post-login.d.ts
+++ b/src/types/api/post-login.d.ts
@@ -50,6 +50,10 @@ export interface PostLogin {
     enable(provider: string, options?: MultifactorEnableOptions): PostLogin;
   };
 
+  readonly prompt: {
+    render(promptId: string, promptOptions?: { [key: string]: unknown }): void;
+  };
+
   readonly rules: {
     wasExecuted(ruleId: string): boolean;
   };


### PR DESCRIPTION
This PR adds support for testing [form rendering](https://auth0.com/docs/customize/forms/render) from within actions.