### PR TITLE
Fix prompt testing

### DIFF
--- a/examples/Login/render-prompt.js
+++ b/examples/Login/render-prompt.js
@@ -1,0 +1,6 @@
+/**
+ * Shows how to test the rendering of a prompt.
+ */
+exports.onExecutePostLogin = async (event, api) => {
+  api.prompt.render("test-prompt-id");
+};

--- a/examples/Login/render-prompt.test.js
+++ b/examples/Login/render-prompt.test.js
@@ -1,0 +1,22 @@
+const test = require("node:test");
+const { strictEqual } = require("node:assert");
+const { onExecutePostLogin } = require("./render-prompt");
+const { nodeTestRunner } = require("@kilterset/auth0-actions-testing");
+
+test("rendering a prompt", async (t) => {
+  const { auth0 } = await nodeTestRunner.actionTestSetup(t);
+
+  await t.test("renders a prompt", async () => {
+    const action = auth0.mock.actions.postLogin();
+
+    await action.simulate(onExecutePostLogin);
+
+    const { rendered } = action.prompt;
+
+    strictEqual(
+      rendered.promptId,
+      "test-prompt-id",
+      "Expected prompt ID to be `test-prompt-id`"
+    );
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kilterset/auth0-actions-testing",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Test and develop Auth0 Actions or Okta CIC Actions locally.",
   "repository": "https://github.com/kilterset/auth0-actions-testing",
   "homepage": "https://github.com/kilterset/auth0-actions-testing#readme",

--- a/src/mock/api/post-login.ts
+++ b/src/mock/api/post-login.ts
@@ -1,4 +1,4 @@
-import Auth0, { Factor, MultifactorEnableOptions } from "../../types";
+import Auth0, { MultifactorEnableOptions, PromptState } from "../../types";
 import { cache as mockCache } from "./cache";
 import { user as mockUser } from "../user";
 import { request as mockRequest } from "../request";
@@ -69,6 +69,7 @@ export interface PostLoginState {
   idToken: {
     claims: Record<string, unknown>;
   };
+  prompt: { rendered: PromptState | null };
   multifactor: {
     enabled:
       | false
@@ -123,6 +124,7 @@ export function postLogin({
     cache: apiCache,
     idToken: idToken.state,
     multifactor: multifactor.state,
+    prompt: prompt.state,
     samlResponse: samlResponse.state,
     validation: validation.state,
     get redirect() {

--- a/src/mock/api/prompt.ts
+++ b/src/mock/api/prompt.ts
@@ -1,9 +1,4 @@
-import { MultifactorEnableOptions } from "../../types";
-
-interface PromptState {
-  promptId: string;
-  promptOptions?: { [key: string]: unknown };
-}
+import { PromptState } from "../../types";
 
 export function promptMock(flow: string) {
   const state: { rendered: PromptState | null } = {

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -6,6 +6,7 @@ export * from "./connection";
 export * from "./factor";
 export * from "./identity";
 export * from "./organization";
+export * from "./prompt";
 export * from "./request";
 export * from "./risk-assessment";
 export * from "./session";

--- a/src/types/prompt.d.ts
+++ b/src/types/prompt.d.ts
@@ -1,0 +1,4 @@
+export interface PromptState {
+  promptId: string;
+  promptOptions?: { [key: string]: unknown };
+}


### PR DESCRIPTION
This PR fixes the implementation of #33, which was missing the `state` necessary to test the prompt rendering.

I have added an example test to be 100% sure that the API works now.