### PR TITLE
Add transaction metadata support for PostLogin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 dist/
+*.tsbuildinfo

--- a/examples/Login/transaction-metadata.js
+++ b/examples/Login/transaction-metadata.js
@@ -1,0 +1,13 @@
+/**
+ * Shows how to use transaction metadata to share state between Actions in the
+ * same login flow. Here we record that a step-up check has run, so a later
+ * Action in the sequence can read it back and avoid repeating the work.
+ */
+exports.onExecutePostLogin = async (event, api) => {
+  if (event.transaction?.metadata?.step_up_completed === "true") {
+    // A previous Action in this transaction already handled step-up.
+    return;
+  }
+
+  api.transaction.setMetadata("step_up_completed", "true");
+};

--- a/examples/Login/transaction-metadata.test.js
+++ b/examples/Login/transaction-metadata.test.js
@@ -1,0 +1,36 @@
+const test = require("node:test");
+const { strictEqual, deepStrictEqual } = require("node:assert");
+const { onExecutePostLogin } = require("./transaction-metadata");
+const { nodeTestRunner } = require("@kilterset/auth0-actions-testing");
+
+test("transaction metadata", async (t) => {
+  const { auth0 } = await nodeTestRunner.actionTestSetup(t);
+
+  await t.test("records the step-up check on the transaction", async () => {
+    const action = auth0.mock.actions.postLogin();
+
+    await action.simulate(onExecutePostLogin);
+
+    // The value written via `api.transaction.setMetadata` is readable on the
+    // event, mirroring how a later Action in the flow would see it.
+    strictEqual(
+      action.event.transaction.metadata.step_up_completed,
+      "true"
+    );
+    strictEqual(action.transaction.metadata.step_up_completed, "true");
+  });
+
+  await t.test("does nothing when step-up already recorded", async () => {
+    const action = auth0.mock.actions.postLogin({
+      transaction: auth0.mock.transaction({
+        metadata: { step_up_completed: "true" },
+      }),
+    });
+
+    await action.simulate(onExecutePostLogin);
+
+    deepStrictEqual(action.transaction.metadata, {
+      step_up_completed: "true",
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kilterset/auth0-actions-testing",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kilterset/auth0-actions-testing",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "license": "ISC",
       "dependencies": {
         "@types/chance": "^1.1.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kilterset/auth0-actions-testing",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Test and develop Auth0 Actions or Okta CIC Actions locally.",
   "repository": "https://github.com/kilterset/auth0-actions-testing",
   "homepage": "https://github.com/kilterset/auth0-actions-testing#readme",

--- a/src/mock/actions/post-login.ts
+++ b/src/mock/actions/post-login.ts
@@ -16,7 +16,7 @@ export function postLogin({
   Omit<PostLoginOptions, "user" | "request"> = {}) {
   const event = events.postLogin(attributes);
 
-  const { request, user } = event;
+  const { request, transaction, user } = event;
 
   const { implementation, state } = api.postLogin({
     user,
@@ -24,6 +24,7 @@ export function postLogin({
     now,
     executedRules,
     cache,
+    transaction,
   });
 
   async function simulate(handler: Handler) {

--- a/src/mock/api/post-login.ts
+++ b/src/mock/api/post-login.ts
@@ -11,6 +11,7 @@ import { promptMock } from "./prompt";
 import { redirectMock } from "./redirect";
 import { userMock } from "./user";
 import { samlResponseMock } from "./saml-response";
+import { transactionMock } from "./transaction";
 import { validationMock } from "./validation";
 import { rulesMock } from "./rules";
 
@@ -20,6 +21,7 @@ export interface PostLoginOptions {
   executedRules?: string[];
   now?: ConstructorParameters<typeof Date>[0];
   request?: Auth0.Request;
+  transaction?: Auth0.Transaction;
 }
 
 type SamlAttributeValue =
@@ -79,6 +81,7 @@ export interface PostLoginState {
         };
   };
   samlResponse: SamlResponseState;
+  transaction: { metadata: Record<string, string | number | boolean> };
   validation: {
     error: { code: string; message: string } | null;
   };
@@ -91,6 +94,7 @@ export function postLogin({
   cache,
   executedRules: optionallyExecutedRules,
   now: nowValue,
+  transaction,
 }: PostLoginOptions = {}) {
   const userValue = user ?? mockUser();
   const executedRules = optionallyExecutedRules ?? [];
@@ -113,6 +117,9 @@ export function postLogin({
   });
   const userApiMock = userMock("PostLogin", { user: userValue });
   const samlResponse = samlResponseMock("PostLogin");
+  const transactionApiMock = transactionMock("PostLogin", {
+    metadata: transaction?.metadata,
+  });
   const validation = validationMock("PostLogin");
   const rules = rulesMock("PostLogin", { executedRules });
 
@@ -126,6 +133,7 @@ export function postLogin({
     multifactor: multifactor.state,
     prompt: prompt.state,
     samlResponse: samlResponse.state,
+    transaction: transactionApiMock.state,
     validation: validation.state,
     get redirect() {
       return redirect.state.target;
@@ -169,6 +177,10 @@ export function postLogin({
 
     get samlResponse() {
       return samlResponse.build(api);
+    },
+
+    get transaction() {
+      return transactionApiMock.build(api);
     },
 
     get user() {

--- a/src/mock/api/transaction.ts
+++ b/src/mock/api/transaction.ts
@@ -1,0 +1,22 @@
+type TransactionMetadata = Record<string, string | number | boolean>;
+
+export function transactionMock(
+  flow: string,
+  { metadata = {} }: { metadata?: TransactionMetadata } = {}
+) {
+  const state = { metadata };
+
+  const build = <API>(api: API) => ({
+    setMetadata: (key: string, value: string | number | boolean | null) => {
+      if (value === null) {
+        delete state.metadata[key];
+      } else {
+        state.metadata[key] = value;
+      }
+
+      return api;
+    },
+  });
+
+  return { build, state };
+}

--- a/src/mock/transaction.ts
+++ b/src/mock/transaction.ts
@@ -8,6 +8,7 @@ export const transaction = define<Auth0.Transaction>(({ params }) => {
   return {
     acr_values: [],
     locale,
+    metadata: {},
     ui_locales: [locale],
     requested_scopes: [],
     protocol: chance.auth0().protocol(),

--- a/src/test/api/post-login.test.ts
+++ b/src/test/api/post-login.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import { strictEqual, deepStrictEqual, throws, ok } from "node:assert";
 import { postLogin } from "../../mock/api";
-import { request, user } from "../../mock";
+import { request, transaction, user } from "../../mock";
 import { encodeHS256JWT } from "../../jwt/hs256";
 
 test("PostLogin API", async (t) => {
@@ -51,6 +51,50 @@ test("PostLogin API", async (t) => {
     const { implementation: api, state } = postLogin();
     strictEqual(api.user.setUserMetadata("favourite_pet", "cat"), api);
     deepStrictEqual(state.user.user_metadata, { favourite_pet: "cat" });
+  });
+
+  await t.test("transaction metadata", async (t) => {
+    await t.test("is chainable", async (t) => {
+      const { implementation: api } = postLogin();
+      strictEqual(api.transaction.setMetadata("planet", "earth"), api);
+    });
+
+    await t.test("sets and overwrites metadata", async (t) => {
+      const { implementation: api, state } = postLogin();
+      api.transaction.setMetadata("planet", "earth");
+      deepStrictEqual(state.transaction.metadata, { planet: "earth" });
+      api.transaction.setMetadata("planet", "mars");
+      deepStrictEqual(state.transaction.metadata, { planet: "mars" });
+    });
+
+    await t.test("preserves number and boolean values", async (t) => {
+      const { implementation: api, state } = postLogin();
+      api.transaction.setMetadata("risk_score", 45);
+      api.transaction.setMetadata("verified", true);
+      deepStrictEqual(state.transaction.metadata, {
+        risk_score: 45,
+        verified: true,
+      });
+    });
+
+    await t.test("removes a key when set to null", async (t) => {
+      const { implementation: api, state } = postLogin();
+      api.transaction.setMetadata("planet", "earth");
+      api.transaction.setMetadata("planet", null);
+      deepStrictEqual(state.transaction.metadata, {});
+    });
+
+    await t.test("starts from existing transaction metadata", async (t) => {
+      const { implementation: api, state } = postLogin({
+        transaction: transaction({ metadata: { source: "google" } }),
+      });
+      deepStrictEqual(state.transaction.metadata, { source: "google" });
+      api.transaction.setMetadata("verified", "true");
+      deepStrictEqual(state.transaction.metadata, {
+        source: "google",
+        verified: "true",
+      });
+    });
   });
 
   await t.test("can set ID token claims", async (t) => {

--- a/src/types/api/post-login.d.ts
+++ b/src/types/api/post-login.d.ts
@@ -82,6 +82,18 @@ export interface PostLogin {
     }): any;
   };
 
+  readonly transaction: {
+    /**
+     * Set a metadata value on the current transaction. The value is readable as
+     * `event.transaction.metadata[key]` by this and subsequent Actions in the
+     * same login flow. Passing `null` removes the key.
+     */
+    setMetadata(
+      key: string,
+      value: string | number | boolean | null
+    ): PostLogin;
+  };
+
   readonly user: {
     setAppMetadata: (key: string, value: string) => PostLogin;
     setUserMetadata: (key: string, value: string) => PostLogin;

--- a/src/types/transaction.d.ts
+++ b/src/types/transaction.d.ts
@@ -3,6 +3,14 @@ export interface Transaction {
   linking_id?: string;
   locale: string;
   login_hint?: string;
+
+  /**
+   * Metadata associated with the transaction, set by previous Actions in the
+   * same login flow via `api.transaction.setMetadata`. Values persist across
+   * sequential Actions and survive interruptions such as MFA or redirects.
+   */
+  metadata?: { [key: string]: string | number | boolean };
+
   prompt?: string[];
 
   protocol?: (


### PR DESCRIPTION
Mocks Auth0 [transaction metadata](https://auth0.com/docs/customize/actions/transaction-metadata) for the PostLogin flow:

- **Read:** `event.transaction.metadata`
- **Write:** `api.transaction.setMetadata(key, value)` (passing `null` removes a key)

Covered by unit tests and a runnable example. Bumps version to 0.3.6.